### PR TITLE
feat: add kernel boot, header and tty

### DIFF
--- a/include/boot.c
+++ b/include/boot.c
@@ -1,0 +1,79 @@
+#include "boot/boot.h"
+#include "kernel/kernel.h"
+#include "tty/serial/serial.h"
+#include "machine/pt.c"
+
+extern void _header_checksum;
+
+extern void kernel_main(void);
+
+struct start header_t = {
+        /**
+        * kernel header:
+        * .magic        : magic number is ‘‘ANDR’’ in ASCII
+        * .kernel_entry : physical entry point of the kernel
+        * .flag         : serial tty flag; ‘0’ to enable tty, ‘1’ to disable
+        * .checksum     : sum is equal to magic number + kernel entry addr + flag
+        * .hgh_mem      : start of higher memory region
+        * .cmdline	: tty0 flag; ‘1’ to enable tty0, ‘0’ to disable
+        */
+
+        .magic        = KERNEL_MAGIC,                          
+        .kernel_entry = (uintptr_t)kernel_main,                
+        .flags        = 0x00000001,                            
+        .checksum     = (uint32_t)addr(_header_checksum),
+        .hgr_mem      = 0x1000,
+        .cmdline      = 0
+};
+
+int early_kernel_init(struct start *hdr)
+{
+        /* checks if the loaded kernel header matches */
+        
+        if (hdr->magic != KERNEL_MAGIC) return 0;
+        
+        uint32_t chk = hdr->magic + (uint32_t)hdr->kernel_entry + hdr->flags;
+        if (hdr->checksum != 0 && chk != hdr->checksum) return 0;
+
+        if (hdr->hgr_mem < 0x1000) return 0;
+        
+        return 1;
+}
+
+void early_kernel_main()
+{
+        /**
+         * makes sure CPU does not execute any instructions in case the header is incorrect,
+         * and enables tty if flag is on, and enables paging before handoff
+         */
+
+        struct start *hdr = (struct start *)(addr(header_t) - HEADER_OFFSET);
+
+        if (!early_kernel_init(hdr)) {
+
+                for (;;) {
+
+                        __asm__("hlt");
+                }
+        }
+
+	char* ok = phys((char*)"systemd : [ OK ] headers validated\n");
+
+        if (hdr->flags & 0x1) {
+
+                early_serial_init(UART_PORT_COM1);
+
+                serial_write(UART_PORT_COM1, ok);
+        }
+
+#ifdef _TTY_TTY0_H
+	if (hdr->cmdline & 0x1) {
+		
+		tty_init();
+
+		tty_writeline(ok);
+	}
+#endif
+        setup_page_tables();
+}
+

--- a/include/boot/boot.h
+++ b/include/boot/boot.h
@@ -1,0 +1,24 @@
+#ifndef _BOOT_H_
+#define _BOOT_H_
+
+#include<stdint.h>
+
+#define HEADER_OFFSET 0xC0000000U
+
+#define KERNEL_MAGIC 0x414e4452
+
+struct start {
+        uint32_t magic;
+        uintptr_t kernel_entry;
+        uint32_t flags;
+        uint32_t checksum;
+        uint32_t hgr_mem;
+        uint32_t cmdline;
+} __attribute__((packed));
+
+int early_kernel_init(struct start*);
+
+void early_kernel_main(void);
+
+#endif /* _BOOT_H_ */
+

--- a/include/boot/grub/grub.cfg
+++ b/include/boot/grub/grub.cfg
@@ -1,0 +1,8 @@
+set timeout=0
+set default=0
+
+menuentry "andromache" {
+    multiboot2 /boot/kernel.elf
+    
+    boot
+}

--- a/include/boot/head.S
+++ b/include/boot/head.S
@@ -1,0 +1,66 @@
+.set MAGIC, 0xe85250d6
+.set PROTECTION_MODE, 0
+.set HEADER_LENGTH, 32
+.set CHECKSUM, -(MAGIC + PROTECTION_MODE + HEADER_LENGTH)
+
+.set VIRTUAL_BASE, 0xC0000000
+.set CR0_PG, 0X80000000
+
+.section .multiboot
+.balign 8
+header_start:
+    .long MAGIC
+    .long PROTECTION_MODE
+    .long HEADER_LENGTH
+    .long CHECKSUM
+
+    .balign 8
+    .short 1
+    .short 0
+    .long 8
+
+    .balign 8
+    .short 0
+    .short 0
+    .long 8
+header_end:
+
+.section .text
+.global _start
+_start:
+    movl $stack_top, %esp
+    subl $VIRTUAL_BASE, %esp
+
+    movl $_init, %eax
+    subl $VIRTUAL_BASE, %eax
+    call *%eax
+
+    movl $early_kernel_main, %eax
+    subl $VIRTUAL_BASE, %eax
+    call *%eax
+
+    movl $boot_page_directory, %eax
+    subl $VIRTUAL_BASE, %eax
+    movl %eax, %cr3
+
+    movl %cr0, %eax
+    orl $CR0_PG, %eax
+    movl %eax, %cr0
+    
+    movl $1f, %eax
+    jmp *%eax
+
+1:
+    addl $VIRTUAL_BASE, %esp
+    
+    call kernel_main
+    
+    cli
+2:
+    hlt
+    jmp 2b
+
+.section .bss
+.balign 16
+stack_top:
+    .skip 16384

--- a/include/boot/kernel.ld
+++ b/include/boot/kernel.ld
@@ -1,0 +1,34 @@
+ENTRY(_start)
+
+LOGIC_BASE = 0xC0000000;
+PHYS_BASE = 1M;
+
+SECTIONS
+{
+    . = LOGIC_BASE + PHYS_BASE;
+    __kernel_start = .;
+
+    .text ALIGN(4K) : AT(ADDR(.text) - LOGIC_BASE) {
+        KEEP(*(.multiboot))
+        *(.text*)
+    }
+
+    .rodata ALIGN(4K) : AT(ADDR(.rodata) - LOGIC_BASE) {
+        *(.rodata*)
+    }
+
+    .data ALIGN(4K) : AT(ADDR(.data) - LOGIC_BASE) {
+        *(.data*)
+    }
+
+    .bss ALIGN(4K) : AT(ADDR(.bss) - LOGIC_BASE) {
+        __bss_start = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end = .;
+    }
+
+    _header_checksum = 0x414E4452 + kernel_main + 0x1;
+
+    __kernel_end = .;
+}

--- a/include/crti.S
+++ b/include/crti.S
@@ -1,0 +1,13 @@
+.section .init
+.global _init
+.type _init, @function
+_init:
+	push %ebp
+	movl %esp, %ebp
+
+.section .fini
+.global _fini
+.type _fini, @function
+_fini:
+	push %ebp
+	movl %esp, %ebp

--- a/include/crtn.S
+++ b/include/crtn.S
@@ -1,0 +1,7 @@
+.section .init
+	popl %ebp
+	ret
+
+.section .fini
+	popl %ebp
+	ret

--- a/include/tty/serial/serial.c
+++ b/include/tty/serial/serial.c
@@ -1,0 +1,26 @@
+#include "machine/io.h"
+#include "serial.h"
+
+void early_serial_init(uint16_t port) 
+{
+    outb(port + UART_IER, 0x00);          // Disable interrupts
+    outb(port + UART_LCR, UART_LCR_DLAB); // Enable DLAB
+    outb(port + 0, 0x01);                 // 115200 baud (divisor 1)
+    outb(port + 1, 0x00);
+    outb(port + UART_LCR, 0x03);          // 8n1
+    outb(port + UART_FCR, 0xC7);          // Enable FIFO
+}
+
+void serial_putc(uint16_t port, char c) 
+{
+    while (!(inb(port + UART_LSR) & UART_LSR_THRE));
+    outb(port, c);
+}
+
+void serial_write(uint16_t port, const char* str) 
+{
+    for (int i = 0; str[i] != '\0'; i++) {
+        if (str[i] == '\n') serial_putc(port, '\r');
+        serial_putc(port, str[i]);
+    }
+}

--- a/include/tty/serial/serial.h
+++ b/include/tty/serial/serial.h
@@ -1,0 +1,19 @@
+#include<stdint.h>
+
+#define UART_PORT_COM1 0x3F8
+
+/* Register Offsets */
+#define UART_TX     0  // Transmit
+#define UART_IER    1  // Interrupt Enable
+#define UART_FCR    2  // FIFO Control
+#define UART_LCR    3  // Line Control
+#define UART_MCR    4  // Modem Control
+#define UART_LSR    5  // Line Status
+
+/* Bitmasks */
+#define UART_LCR_DLAB 0x80 // Divisor Latch Access Bit
+#define UART_LSR_THRE 0x20 // Transmit Holding Register Empty
+
+void early_serial_init(uint16_t);
+void serial_putc(uint16_t, char);
+void serial_write(uint16_t port, const char* str);

--- a/include/tty/tty0/tty0.h
+++ b/include/tty/tty0/tty0.h
@@ -1,0 +1,20 @@
+#ifndef _TTY_TTY0_H
+#define _TTY_TTY0_H
+
+#include<stdint.h>
+#include "tty/vga.h"
+
+static uint32_t tty_row;
+static uint32_t tty_col;
+static uint32_t tty_color;
+static uintptr_t tty_buf;
+
+void tty_init(void);
+void tty_setcolor(vga_color);
+void tty_scroll(uint32_t);
+void tty_putc(char);
+void tty_writeline(char*);
+void tty_clearline(void);
+void tty_putc_at(char, enum vga_color, uint32_t, uint32_t);
+
+#endif /* _TTY_TT0_H */

--- a/include/tty/tty0/tty0.h
+++ b/include/tty/tty0/tty0.h
@@ -17,4 +17,4 @@ void tty_writeline(char*);
 void tty_clearline(void);
 void tty_putc_at(char, enum vga_color, uint32_t, uint32_t);
 
-#endif /* _TTY_TT0_H */
+#endif /* _TTY_TTY0_H */

--- a/include/tty/vga.h
+++ b/include/tty/vga.h
@@ -1,0 +1,50 @@
+#ifndef _VGA_H
+#define _VGA_H
+
+#include "kernel/kernel.h"
+#include "machine/pt.h"
+
+#define VGA_PHYS_ADDR 0xb8000
+#define VGA_VIRT_BASE phys_to_virt(VGA_PHYS_ADDR)
+
+#define VGA_HEIGHT 80
+#define VGA_WIDTH 20
+
+enum vga_color {
+
+	VGA_COLOR_BLACK 	= 0, 
+	VGA_COLOR_BLUE		= 1,
+	VGA_COLOR_GREEN		= 2,
+	VGA_COLOR_CYAN		= 3,
+	VGA_COLOR_RED		= 4,
+	VGA_COLOR_MAGENTA	= 5,
+	VGA_COLOR_BROWN		= 6,
+	VGA_COLOR_LIGHT_GREY	= 7,
+	VGA_COLOR_DARK_GREY	= 8,
+	VGA_COLOR_LIGHT_BLUE	= 9,
+	VGA_COLOR_LIGHT_GREEN	= 10,
+	VGA_COLOR_LIGHT_CYAN	= 11,
+	VGA_COLOR_LIGHT_RED	= 12,
+	VGA_COLOR_LIGHT_MAGENTA = 13,
+	VGA_COLOR_LIGHT_BROWN	= 14,
+	VGA_COLOR_WHITE		= 15,
+
+};
+
+static inline u8 vga_entry_color(enum vga_color fg, enum vga_color bg)
+{
+	return fg | bg << 4;
+}
+
+static inline u16 vga_entry(unsigned char uc, u8 color)
+{
+	return (u16) uc | (u16) color << 8;
+}
+
+static inline void vga_setup_page(u32* pt)
+{
+	pt[VGA_VIRT_BASE >> 12] = VGA_PHYS_ADDR | 0x3;
+}
+
+#endif /* _VGA_H */
+         

--- a/include/tty/vga.h
+++ b/include/tty/vga.h
@@ -7,8 +7,8 @@
 #define VGA_PHYS_ADDR 0xb8000
 #define VGA_VIRT_BASE phys_to_virt(VGA_PHYS_ADDR)
 
-#define VGA_HEIGHT 80
-#define VGA_WIDTH 20
+#define VGA_WIDTH 80
+#define VGA_HEIGHT 20
 
 enum vga_color {
 


### PR DESCRIPTION
# Summary

The changes set up a kernel header which is verified at ‘‘boot time’’, and defines headers for serial and cmdline-style tty, and actually uses a serial tty to print a verification message. It also sets up the trampoline code, and linker script.

A VGA header is also provided in case the latter tty is fleshed out and expanded.

# Headers

The boot header defines the ‘‘special’’ kernel header. The header contains a basic checksum; specifically contains the higher memory boundary, and then some tty flags. It should only concern boot. You should be aware that
```c
__attribute__((packed))
```
was used, because the header has to be contiguous. The performance slowdown due to the ‘‘extra’’ instructions is acceptable here. 

VGA page reservation is written as a small static inline function
```c
static inline void vga_setup_page(u32* pt)
{
	pt[VGA_VIRT_BASE >> 12] = VGA_PHYS_ADDR | 0x3;
}
```
 which simply sets it directly when called.
 
 The two ttys provide the same interface as can be found [here](https://wiki.osdev.org/Meaty_Skeleton). (They are worth expanding however.)

## Macros

The serial macros may seem redundant, but they are worth keeping in case implementation of serial; the file itself is mostly taken from the Linux kernel project, but even there, not all macros are used. 🤷 

`vga.h` is the only place where VGA virtual mem. boundary is defined.

The kernel header virtual memory offset and magic number are of course, in boot.

## Note

The former does not actually initialize, but merely checks. The handoff happens with the latter function (see ASM section).
```c
int early_kernel_init(struct start*);

void early_kernel_main(void);
```

# ASM & Linker

The header is specific to multiboot2 and avoids mutliboot1, because of how cluttered it is. The ELF header is standard and specific of course to x86.

The important part is here:

```asm
    movl $stack_top, %esp
    subl $VIRTUAL_BASE, %esp

    movl $_init, %eax
    subl $VIRTUAL_BASE, %eax
    call *%eax

    movl $early_kernel_main, %eax
    subl $VIRTUAL_BASE, %eax
    call *%eax

    movl $boot_page_directory, %eax
    subl $VIRTUAL_BASE, %eax
    movl %eax, %cr3
 ```
    
The stack set up is reserved by the same amount as the virtual memory boundary at first. The _init is a special call to `crti.S`, compiler-specific caller that early on makes sure that globals and constructors are called, populated and created in the symbol table. The handoff as aforementioned happens with `early_kernel_main()`, and again is ‘‘trampolined’’ by the virtual memory base.
    
The paging setup also is pushed onto the correct stack and trampolined likewise.

This setup now allows us to ‘‘jump’’ into virtual mode, which is exactly what happens by pushing the pagetable:
```asm
    movl %cr0, %eax
    orl $CR0_PG, %eax
    movl %eax, %cr0

    movl $1f, %eax
    jmp *%eax
```
 and then ‘‘hard-jumping’’ into the main kernel function right away.
    
It then does a manual ‘‘barrier()’’ call by ignoring interrupts, and then ‘‘hlt’’ so the %eip doesn’t go into further instructions.

## Linker script

The checksum variable is defined here (and externed later...). The chosen memory layout follows the old physical base .1M, although we might consider easily using .2M, and also, virtual base `0xc0000000`.
    
## Note

There are plans to replace that kernel_main call with kernel_init that have not transpired yet!

# Impl. notes

The init as aforementioned does not actually initialize: it checks the header. It can be considered a helper function (so, inlineable).

The kernel header is also defined along with some basic documentation. The early main routine checks for tty flags, and then prints to the serial one a message if the header was validated, otherwise it will simply `hlt`.

It still operates in physical mode (hence the phys, addr macro calls from kernel.h), but then:

Paging setup is called, which is a relief.

---
## Progress 🧑‍💻
- [x] **1. Boot Layer & TTY** (here!)
- [ ] 2. Machine Layer (#12)
- [ ] 3. Task Structure (#13)
- [ ] 4. Child Handler (#14)
- [ ] 5. Docs & Scripts (#15)
