### PR TITLE
feat: add asm headers, page table, irq, tss_struct

### DIFF
--- a/include/machine/barrier.h
+++ b/include/machine/barrier.h
@@ -1,0 +1,27 @@
+#ifndef _BARRIER_H_
+#define _BARRIER_H_
+
+#include<stdint.h>
+
+static inline void barrier(void)
+{
+	__asm__ volatile("" : : : "memory");
+}
+
+static inline void mb(void)
+{
+	__asm__ volatile("mfence" : : : "memory");
+}
+
+static inline void rmb(void)
+{
+	__asm__ volatile("lfence" : : : "memory");
+}
+
+static inline void wmb(void)
+{
+	__asm__ volatile("sfence" : : : "memory");
+}
+
+
+#endif /* _BARRIER_H_ */

--- a/include/machine/io.h
+++ b/include/machine/io.h
@@ -1,0 +1,23 @@
+#ifndef _IO_H_
+#define _IO_H_
+
+#include <stdint.h>
+
+static inline void outb(uint16_t port, uint8_t val) 
+{
+    __asm__ volatile ( "outb %0, %1" : : "a"(val), "Nd"(port) );
+}
+
+static inline uint8_t inb(uint16_t port) 
+{
+    uint8_t ret;
+    __asm__ volatile ( "inb %1, %0" : "=a"(ret) : "Nd"(port) );
+    return ret;
+}
+
+static inline void io_wait(void) 
+{
+    outb(0x80, 0);
+}
+
+#endif /* _IO_H_ */

--- a/include/machine/irqflags.h
+++ b/include/machine/irqflags.h
@@ -1,0 +1,55 @@
+#ifndef _IRQFLAGS_H_
+#define _IRQFLAGS_H_
+
+#include<stdint.h>
+#include "barrier.h"
+
+static inline void enable(void) 
+{
+	__asm__ volatile("sti"
+			: : : "memory"
+			);
+}
+
+static inline void disable(void)
+{
+	__asm__ volatile("cli"
+		: : : "memory"
+		);
+}
+
+static inline unsigned long save_flags(void)
+{
+	unsigned long flags;
+
+	__asm__ volatile("pushfd ; pop %0"
+		: "=g"(flags) : : "memory"
+		);
+
+	return flags;
+}
+
+static inline void restore_flags(unsigned long flags)
+{
+	__asm__ volatile("push %0 ; popfd"
+		: : "g"(flags) : "memory"
+		);
+}
+
+static inline void save_irq_state(unsigned long *flags)
+{
+	*flags = save_flags();
+	
+	disable();
+	barrier();
+}
+
+static inline void restore_irq_state(unsigned long *flags)
+{
+	barrier();
+
+	restore_flags(*flags);
+}
+
+#endif /* _IRQFLAGS_H_ */
+

--- a/include/machine/processor.h
+++ b/include/machine/processor.h
@@ -1,0 +1,42 @@
+#ifndef _PROCESSOR_H_
+#define _PROCESSOR_H_
+
+#include<stdint.h>
+#include "kernel/kernel.h"
+#include "pt.h"
+
+#define CR3_ADDR_MASK 0xffffffffU
+#define CR3_PCID_MASK 0
+#define CR3_NOFLUSH   0
+
+// ! to be declared...
+struct hw_tss;
+struct io_bitmap;
+
+struct task_frame {
+	u32 flags;
+	u32 si;
+	u32 di;
+	u32 bx;
+	u32 bp;	
+};
+
+struct tss_struct {
+	_Alignas(PAGE_SIZE) struct hw_tss *tss;
+	struct io_bitmap *io_bitmap;
+};
+
+struct __task_struct {
+	u32 sp;
+	u32 ip;
+	u32 sp0;
+};
+
+static inline void load_cr3(u32 pgdir_phys_addr)
+{
+	__asm__ volatile("movl %0, %%cr3"
+			: : "r" (pgdir_phys_addr) : "memory"
+			);
+}
+
+#endif /* _PROCESSOR_H_ */

--- a/include/machine/pt.c
+++ b/include/machine/pt.c
@@ -1,0 +1,30 @@
+#include<stdint.h>
+
+#include "kernel/kernel.h"
+#include "pt.h"
+#include "tty/vga.h"
+
+void setup_page_tables()
+{
+	u32 *pd = phys((u32*)boot_page_directory);
+	u32 *pt = phys((u32*)boot_page_table1);
+
+	uintptr_t phys_pd = (uintptr_t)pd;
+	uintptr_t phys_pt = (uintptr_t)pt;
+
+	for (int i = 0; i < 1024; ++i) {
+
+		pd[i] = 0;
+		pt[i] = 0;
+	}
+
+	pd[0] 	= phys_pt | 0x3;
+	pd[768] = phys_pt | 0x3;
+
+	for (int i = 0; i < 1024; ++i) {
+		
+		pt[i] = (i * PAGE_SIZE) | 0x3;
+	}
+
+	vga_setup_page(pt);
+}

--- a/include/machine/pt.h
+++ b/include/machine/pt.h
@@ -1,0 +1,20 @@
+#ifndef _PT_H_
+#define _PT_H_
+
+#include<stdint.h>
+#include "kernel/kernel.h"
+
+extern u8 LOGIC_BASE;
+
+#define PAGE_SIZE 4096
+
+#define addr(var) ((uintptr_t)(void*)&(var))
+
+#define phys(ptr) ((__typeof__(ptr))(uintptr_t)((uintptr_t)ptr - addr(LOGIC_BASE))) 
+
+_Alignas(PAGE_SIZE) u32 boot_page_directory[1024];
+_Alignas(PAGE_SIZE) u32 boot_page_table1[1024];
+
+void setup_page_tables(void);
+
+#endif /* _PT_H_ */


### PR DESCRIPTION
# Summary
The paging setup is implemented, along with save-and-restore IRQ. The scaffolding for the context switch implementation is also left in `processor.h`

# Headers

This
```c
_Alignas(PAGE_SIZE)
```

is equivalent to the GCC version

```c
__attribute__((aligned))
```
The former is simply a C11 feature, and it does the same thing.

The inclusion of `(void*)` in the addr macro is not a mistake. If you include it, the compiler will warn you, but here it makes sure you don’t accidentally de-reference a non-l-value, which is very bad if this were to happen after build.

The irq header is nearly identical to what one will find in the wild, but it is worth mentioning that the specific order in which barrier() is called is very important. If one tries to do the save-and-restore, and is interrupted constantly for whatever reason, the kernel will go into unrecoverable state, which is undesirable of course, but what’s worse, memory op order is lost.

These
```c
// ! to be declared...
struct hw_tss;
struct io_bitmap;
```
were left out of implementation because they are primary useful for the context switch, and not other features relevant here.

```c
struct __task_struct
```

is tucked away because it contains the information enabling us to do the first context switch. Its equivalent is thread_struct in Linux kernel project for example.

`barrier()` itself is implemented for 86_32x, but it is really just equivalent to an atomic ‘‘_do not change memory ops_’’. (The compiler does love to do that...)

# Impl. notes

The pagetable setup first zeros both pd, pt, and then the first and half entries are bit masked. The pager is then mapped directly.

The VGA page setup is also called, although perhaps it could be made optional later, since if the tty is not enabled, this is wasting performance.

---
## Progress 🧑‍💻
- [x] 1. Boot Layer & TTY (#11)
- [x] **2. Machine Layer** (here!)
- [ ] 3. Task Structure (#13)
- [ ] 4. Child Handler (#14)
- [ ] 5. Docs & Scripts (#15)
