### PR TITLE
feat: create task_struct

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,8 +1,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define CONFIG_MAX_THREADS     64
-#define CONFIG_ENABLE_IPC      1
-#define CONFIG_SCHEDULER_RR    1
+#define CONFIG_ENABLE_IPC   1
+#define CONFIG_SCHEDULER_RR 1
 
 #endif /* CONFIG_H */

--- a/include/kernel/kernel.h
+++ b/include/kernel/kernel.h
@@ -2,6 +2,15 @@
 #define KERNEL_KERNEL_H
 
 #include <stdint.h>
+#include "boot/boot.h"
+
+typedef uint32_t u32;
+typedef uint16_t u16;
+typedef uint8_t  u8;
+
+typedef u32 addr_t;
+
+#define phys_to_virt(addr) ((addr) + HEADER_OFFSET)
 
 void kernel_init(void);
 

--- a/include/kernel/signal.h
+++ b/include/kernel/signal.h
@@ -1,0 +1,6 @@
+#ifndef _KERNEL_SIGNAL_H_
+#define _KERNEL_SIGNAL_H_
+
+void signal_init(void);
+
+#endif /* _KERNEL_SIGNAL_H_ */

--- a/include/kernel/task.h
+++ b/include/kernel/task.h
@@ -1,0 +1,25 @@
+#ifndef _KERNEL_TASK_H
+#define _KERNEL_TASK_H
+
+#include "kernel.h"
+#include "machine/processor.h"
+
+/**
+ * I shall henceforth, forward-declare a great many declarations...
+ * */
+enum pd_state {_=0,};
+struct mm_struct;
+
+struct task_struct {
+	u16 pid;
+	enum pd_state state;
+	u32 flags;
+	void *stack;
+	struct mm_struct *mm;
+	struct __task_struct __task;
+};
+
+void task_init(void);
+
+#endif /* _KERNEL_TASK_h */
+


### PR DESCRIPTION
# Summary

The regular humble process descriptor along with too many forward declarations... 

# Headers

- `task.h`

The process descriptor contains only the bare minimum and _should_ be moved later to `sched.h`. This
```c
struct __task_struct __task;
```
is the important ‘‘tucked’’ structure discussed in #12. It _should_ remain hard to access.

The stack will be 16 KiB most likely. `mm_struct` holds paging, GDT info.

The state is tied to the scheduler again, which I is another reason why it should be moved altogether to `sched.h` later.

- `kernel.h`

The aliases and helper macros live here.

This is not being used, you are correct... It however should be used. I left it with that intention.
```
void kernel_init(void);
```

- `signal.h`

The intent here is progress, but the signal handler is added in because of how tied it is to the process descriptor in conception AND implementation. There is no major reason to merge it in, but there is no reason for rejecting the scaffold either.

---
## Progress 🧑‍💻
- [x] 1. Boot Layer & TTY (#11)
- [x] 2. Machine Layer (#12)
- [x] **3. Task Structure** (here!)
- [ ] 4. Child Handler (#14)
- [ ] 5. Docs & Scripts (#15)